### PR TITLE
fix: add arch_dependent and os_dependent flags to buildx module exten…

### DIFF
--- a/buildx/extensions.bzl
+++ b/buildx/extensions.bzl
@@ -60,4 +60,6 @@ def _toolchain_extension(module_ctx):
 buildx = module_extension(
     implementation = _toolchain_extension,
     tag_classes = {"toolchains": buildx_toolchain},
+    arch_dependent = True,
+    os_dependent = True,
 )


### PR DESCRIPTION
Porting from: https://github.com/bazel-contrib/rules_oci/pull/841

The buildx repository rule generate a lockfile that has a platform specific `configure_buildx` block that breaks when used across platforms (ie: a MODULE.bazel.lock generated on OSX breaks on Linux_amd64).

ex: Module.bazel.lock
```diff
"buildx": {
    "repoRuleId": "@@//build_utils/docker:buildx.bzl%configure_buildx",
    "attributes": {
+     "buildx": "@@+buildx+buildx_darwin-arm64//file:downloaded",
      "buildx_platforms": {
        "@@+buildx+buildx_linux-amd64//file:file": "@bazel_tools//src/conditions:linux_x86_64",
        "@@+buildx+buildx_linux-arm64//file:file": "@bazel_tools//src/conditions:linux_aarch64",
        "@@+buildx+buildx_darwin-amd64//file:file": "@bazel_tools//src/conditions:darwin_x86_64",
        "@@+buildx+buildx_darwin-arm64//file:file": "@bazel_tools//src/conditions:darwin_arm64"
      }
    }
  }
```

This specifies `arch_dependent` and  `os_dependent` on `module_extension` to workaround this issue.