### PR TITLE
fix: Require override_path for sources build context

### DIFF
--- a/buildx/private/buildx_context.bzl
+++ b/buildx/private/buildx_context.bzl
@@ -61,14 +61,10 @@ def _context_oci_layout(replace, layout):
         "srcs": [name],
     }
 
-def _context_sources(replace, sources, override_path = None):
-    store = "$(location %s)" % sources
-    if override_path:
-        store = override_path
-
+def _context_sources(replace, sources, override_path):
     return {
         "replace": replace,
-        "store": store,
+        "store": override_path,
         "srcs": sources,
     }
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,19 +15,17 @@ Run BuildX to produce OCI base image using a Dockerfile.
 
 **PARAMETERS**
 
-
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="buildx-name"></a>name |  name of the target   |  none |
 | <a id="buildx-dockerfile"></a>dockerfile |  label to the dockerfile to use for this build   |  none |
 | <a id="buildx-path"></a>path |  path to build context where all will be relative to under Dockerfile   |  `"."` |
 | <a id="buildx-srcs"></a>srcs |  additional srcs to read during build   |  `[]` |
-| <a id="buildx-build_context"></a>build_context |  a dictionary for custom build contexes. https://docs.docker.com/reference/cli/docker/buildx/build/#build-context   |  `[]` |
+| <a id="buildx-build_context"></a>build_context |  a dictionary for custom build contexes. <https://docs.docker.com/reference/cli/docker/buildx/build/#build-context>   |  `[]` |
 | <a id="buildx-execution_requirements"></a>execution_requirements |  execution requirements for the action, we recommend using local as BuildX wants to read files outside of the sandbox.   |  `{"local": "1"}` |
-| <a id="buildx-builder_name"></a>builder_name |  name of the builder to use. https://docs.docker.com/reference/cli/docker/buildx/build/#builder   |  `"rules_buildx_builder"` |
+| <a id="buildx-builder_name"></a>builder_name |  name of the builder to use. <https://docs.docker.com/reference/cli/docker/buildx/build/#builder>   |  `"rules_buildx_builder"` |
 | <a id="buildx-tags"></a>tags |  tags for the target   |  `["manual"]` |
 | <a id="buildx-visibility"></a>visibility |  visibility for the target   |  `[]` |
-
 
 <a id="context.oci_layout"></a>
 
@@ -37,16 +35,12 @@ Run BuildX to produce OCI base image using a Dockerfile.
 context.oci_layout(<a href="#context.oci_layout-replace">replace</a>, <a href="#context.oci_layout-layout">layout</a>)
 </pre>
 
-
-
 **PARAMETERS**
-
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="context.oci_layout-replace"></a>replace |  <p align="center"> - </p>   |  none |
 | <a id="context.oci_layout-layout"></a>layout |  <p align="center"> - </p>   |  none |
-
 
 <a id="context.sources"></a>
 
@@ -56,15 +50,10 @@ context.oci_layout(<a href="#context.oci_layout-replace">replace</a>, <a href="#
 context.sources(<a href="#context.sources-replace">replace</a>, <a href="#context.sources-sources">sources</a>, <a href="#context.sources-override_path">override_path</a>)
 </pre>
 
-
-
 **PARAMETERS**
-
 
 | Name  | Description | Default Value |
 | :------------- | :------------- | :------------- |
 | <a id="context.sources-replace"></a>replace |  <p align="center"> - </p>   |  none |
 | <a id="context.sources-sources"></a>sources |  <p align="center"> - </p>   |  none |
-| <a id="context.sources-override_path"></a>override_path |  <p align="center"> - </p>   |  `None` |
-
-
+| <a id="context.sources-override_path"></a>override_path |  <p align="center"> - </p>   |  none |


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

Make `override_path` argument of `context.sources` required.

To my understanding, the current default of `None` is never valid due to the following reason:
- `sources` is required to be a list due to [this list concatenation](https://github.com/aspect-build/rules_buildx/blob/5f57e822aaf35d8645d2e9ee519943804c39af68/buildx/private/buildx_build.bzl#L36C9-L36C21).
- Evaluating `"$(location %s)" % sources` with `sources` being a list [here](https://github.com/aspect-build/rules_buildx/blob/5f57e822aaf35d8645d2e9ee519943804c39af68/buildx/private/buildx_context.bzl#L65) is invalid as `$(location ...)` expects a single label as an argument. 
- Consequently, the `None` default value for `override_path` leads to an evaluation of `$(location ...)` with a list as argument, which fails.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan
None