### PR TITLE
Adds output type=local support

### DIFF
--- a/buildx/BUILD.bazel
+++ b/buildx/BUILD.bazel
@@ -50,6 +50,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "dependencies",
+    srcs = ["dependencies.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@bazel_tools//tools/build_defs/repo:http.bzl",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    ],
+)
+
+bzl_library(
     name = "toolchain",
     srcs = ["toolchain.bzl"],
     visibility = ["//visibility:public"],

--- a/buildx/private/buildx_build.bzl
+++ b/buildx/private/buildx_build.bzl
@@ -11,6 +11,9 @@ def buildx(
         build_context = [],
         execution_requirements = {"local": "1"},
         builder_name = "rules_buildx_builder",
+        outs = None,
+        out_dirs = None,
+        output_type = "oci",
         tags = ["manual"],
         visibility = []):
     """
@@ -24,6 +27,9 @@ def buildx(
         build_context: a dictionary for custom build contexes. https://docs.docker.com/reference/cli/docker/buildx/build/#build-context
         execution_requirements: execution requirements for the action, we recommend using local as BuildX wants to read files outside of the sandbox.
         builder_name: name of the builder to use. https://docs.docker.com/reference/cli/docker/buildx/build/#builder
+        outs: list of output files
+        out_dirs: list of output directories
+        output_type: BuildX output type ("oci" or "local")
         tags: tags for the target
         visibility: visibility for the target
     """
@@ -43,6 +49,20 @@ def buildx(
         visibility = visibility,
     )
 
+    valid_output_types = [ "oci", "local" ]
+    if output_type not in valid_output_types:
+        fail("Invalid output type `{}`. Expected one of {}".format("output_type", ", ".join(valid_output_types)))
+
+    output_arg = None
+    if output_type == "oci":
+        output_arg = "--output=type=oci,tar=false,dest=$@"
+
+    if output_type == "local":
+        output_arg = "--output=type=local,dest=$(RULEDIR)"
+
+    if outs == None and out_dirs == None:
+        out_dirs = [name]
+
     run_binary(
         name = name,
         srcs = [name + "_dockerfile"] + srcs + context_srcs,
@@ -53,13 +73,14 @@ def buildx(
             "$(location {}_dockerfile)".format(name),
             "--builder",
             builder_name,
-            "--output=type=oci,tar=false,dest=$@",
+            output_arg,
             # Set the source date epoch to 0 for better reproducibility.
             "--build-arg SOURCE_DATE_EPOCH=0",
         ] + context_args,
         execution_requirements = execution_requirements,
         mnemonic = "BuildX",
-        out_dirs = [name],
+        outs = outs,
+        out_dirs = out_dirs,
         tool = "@aspect_rules_buildx//buildx:resolved_toolchain",
         tags = tags,
         visibility = visibility,

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -41,7 +41,16 @@ oci_load(
     repo_tags = ["example:latest"],
 )
 
+# BuildX can be used to generate files, not just OCI images.
+# Here we use `apt-get` to install `jq` and then copy it out of the image.
+buildx(
+    name = "jq",
+    outs = [ "jq" ],
+    output_type = "local",
+    dockerfile = ":jq.Dockerfile",
+)
+
 build_test(
     name = "test",
-    targets = [":image"],
+    targets = [":image",":jq"],
 )

--- a/e2e/smoke/jq.Dockerfile
+++ b/e2e/smoke/jq.Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11.9-bullseye
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV LC_ALL=C.UTF-8 \
+    LANG=C.UTF-8 \
+    LANGUAGE=C.UTF-8
+
+RUN apt-get -y update \
+    && apt-get -y install jq \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+FROM scratch
+COPY --from=0 /usr/bin/jq .


### PR DESCRIPTION
This PR adds support for output `type=local`.

This is useful when the desired output from BuildX is a file, not an OCI image.

Whilst it would be possible to build an OCI image, flatten the layers and pick out the desired files, this way is probably more efficient.

I would appreciate some feedback on the UX and can make changes as needed. Thanks!

---

### Changes are visible to end-users: yes

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- New test cases added
