### PR TITLE
Fix release.yaml reference

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: smlx/ccv@7318e2f25a52dcd550e75384b84983973251a1f8 # v0.10.0
   release:
     needs: tag
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/release.yaml
     with:
       tag_name: ${{ needs.tag.outputs.new-tag-version }}
     secrets:


### PR DESCRIPTION
It was failing due to a bad reference (e.g. https://github.com/aspect-build/rules_buildx/actions/runs/27361377753)