### PR TITLE
Fix windows platform matching

### DIFF
--- a/buildx/repositories.bzl
+++ b/buildx/repositories.bzl
@@ -13,7 +13,7 @@ def _buildx_repo_impl(rctx):
     url = "https://github.com/docker/buildx/releases/download/v{version}/buildx-v{version}.{}{suffix}".format(
         rctx.attr.platform,
         version = rctx.attr.buildx_version,
-        suffix = ".exe" if rctx.attr.platform == "windows" else "",
+        suffix = ".exe" if rctx.attr.platform.startswith("windows-") else "",
     )
     rctx.download(
         url = [url],

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -33,6 +33,10 @@ buildx_build(
         "root": ":root_context",
     },
     dockerfile = ":Dockerfile",
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 oci_image(

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -66,12 +66,20 @@ buildx_build(
     name = "curl_buildx_linux_amd64",
     dockerfile = ":curl.Dockerfile",
     platforms = ["linux/arm64"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 buildx_build(
     name = "curl_buildx_linux_arm64",
     dockerfile = ":curl.Dockerfile",
     platforms = ["linux/arm64"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 oci_load(
@@ -86,6 +94,10 @@ buildx_build(
     srcs = ["motd.txt"],
     dockerfile = ":motd.Dockerfile",
     platforms = ["linux/arm64"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 oci_load(

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -54,6 +54,10 @@ buildx_build(
     dockerfile = ":jq.Dockerfile",
     output_type = "local",
     platforms = ["linux/amd64"],
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
 )
 
 # BuildX can accept a list of platforms as an argument.

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -110,6 +110,14 @@ oci_load(
     repo_tags = ["bazel/rules_buildx_motd:latest"],
 )
 
+# Using the toolchain in a genrule
+genrule(
+    name = "version",
+    cmd = """"$(BUILDX_BIN)" version >$@""",
+    outs = ["version.txt"],
+    toolchains = ["@aspect_rules_buildx//buildx:resolved_toolchain"],
+)
+
 build_test(
     name = "test",
     targets = [
@@ -118,5 +126,6 @@ build_test(
         ":curl_buildx_linux_amd64",
         ":curl_buildx_linux_arm64",
         ":motd",
+        ":version",
     ],
 )

--- a/e2e/smoke/BUILD.bazel
+++ b/e2e/smoke/BUILD.bazel
@@ -113,8 +113,8 @@ oci_load(
 # Using the toolchain in a genrule
 genrule(
     name = "version",
-    cmd = """"$(BUILDX_BIN)" version >$@""",
     outs = ["version.txt"],
+    cmd = """"$(BUILDX_BIN)" version >$@""",
     toolchains = ["@aspect_rules_buildx//buildx:resolved_toolchain"],
 )
 

--- a/e2e/smoke/MODULE.bazel
+++ b/e2e/smoke/MODULE.bazel
@@ -12,6 +12,7 @@ bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "aspect_bazel_lib", version = "2.21.2")
 bazel_dep(name = "rules_oci", version = "2.2.6")
 bazel_dep(name = "rules_go", version = "0.61.0")
+bazel_dep(name = "platforms", version = "1.1.0")
 
 # Fetch the base image to be used for the build.
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")

--- a/e2e/smoke/MODULE.bazel.lock
+++ b/e2e/smoke/MODULE.bazel.lock
@@ -252,7 +252,7 @@
   "moduleExtensions": {
     "@@aspect_rules_buildx+//buildx:extensions.bzl%buildx": {
       "os:osx,arch:aarch64": {
-        "bzlTransitiveDigest": "szh1XGtsLAa120yY/TL67tahygTLpq9F4bUdYZg/hhs=",
+        "bzlTransitiveDigest": "0LGkdEPP6euoTJdgb5emFp+LW5QXWfBn3gAB/z29UzI=",
         "usagesDigest": "ZpR2jcmQDJm6iLdWYU3OA5wygPSnNlKJ7JYbD/rhkuc=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_rules_buildx+,aspect_bazel_lib aspect_bazel_lib+",


### PR DESCRIPTION
This small fix gets Windows running 🎉 

I wonder if Windows should be included in the PR automated test process to prevent regressions?

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:

I ran the `rules_img` example on a Windows AMD64 machine.