### PR TITLE
fix: preserve source paths in local build context

### DIFF
--- a/buildx/private/buildx_context.bzl
+++ b/buildx/private/buildx_context.bzl
@@ -12,7 +12,22 @@ def _copy_sources_to_context_impl(ctx):
     output = ctx.actions.declare_directory(ctx.label.name)
     args = ctx.actions.args()
     args.add(output.path)
-    args.add_all(ctx.files.srcs)
+
+    package_prefix = ctx.label.package + "/" if ctx.label.package else ""
+
+    for src in ctx.files.srcs:
+        short_path = src.short_path
+
+        # Keep paths relative to this package when possible.
+        if package_prefix and short_path.startswith(package_prefix):
+            rel_path = short_path[len(package_prefix):]
+        else:
+            # Keep external/other-package files workspace-relative.
+            rel_path = short_path
+
+        args.add(src.path)
+        args.add(rel_path)
+
     ctx.actions.run_shell(
         inputs = ctx.files.srcs,
         outputs = [output],
@@ -26,11 +41,16 @@ shift
 rm -rf "$output"
 mkdir -p "$output"
 
-for src in "$@"; do
+while [ "$#" -gt 0 ]; do
+    src="$1"
+    rel="$2"
+    shift 2
+
     if [ -d "$src" ]; then
         cp -R "$src/." "$output"
     else
-        cp "$src" "$output/$(basename "$src")"
+        mkdir -p "$output/$(dirname "$rel")"
+        cp "$src" "$output/$rel"
     fi
 done
 """,

--- a/e2e/smoke/Dockerfile
+++ b/e2e/smoke/Dockerfile
@@ -15,7 +15,7 @@ RUN pip install cowsay
 
 COPY --from=root . /app
 
-COPY --from=bins_hi hi /usr/local/bin/hi
+COPY --from=bins_hi bins/hi /usr/local/bin/hi
 
 ENTRYPOINT ["/usr/local/bin/python3"]
 


### PR DESCRIPTION
Previously buildx_context_local copied file inputs using basename, which flattened nested files into the context root. This broke Dockerfile COPY paths.

Copy files using their package-relative path so local build contexts keep the expected directory structure.

Example build container image from nodejs source:
Dockerfile
```
FROM node:24-alpine AS builder

WORKDIR /app

COPY --from=web_src package.json /app/package.json

RUN npm install

COPY --from=web_src . ./

RUN npm run build

FROM nginxinc/nginx-unprivileged:1.30-alpine3.23-slim as web

USER nginx

COPY --from=web_src nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf

COPY --from=builder /app/dist /usr/share/nginx/html

EXPOSE 8080
```


<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
